### PR TITLE
fix #122 rolling 0 dice

### DIFF
--- a/commands/roll.js
+++ b/commands/roll.js
@@ -67,7 +67,7 @@ module.exports = {
 		let roll = new YZRoll(game, ctx.author, name, lang);
 
 		// Year Zero Roll Regular Expression.
-		const yzRollRegex = /^((\d{1,2}[dbsgna])|([bsgna]\d{1,2})|(d(6|8|10|12))|([abcd])+)+$/i;
+		const yzRollRegex = /^(([1-9]\d?[dbsgna])|([bsgna][1-9]\d?)|(d(6|8|10|12))|([abcd])+)+$/i;
 
 		// Checks for d6, d66 & d666.
 		const isD66 = rollargv._.length === 1 &&


### PR DESCRIPTION
## Summary
Updating the yzRollRegex to not match \d{1,2} which is inclusive of 0 and leading 0s as in 09 to only be values 1-99.

Regex has only been tested with patterns listed in the issue. Full test of the bot functionality has not been tested.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->
### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes (wiki).