### PR TITLE
fix(Help): 🐛 t is not a function

### DIFF
--- a/src/commands/utils/help.js
+++ b/src/commands/utils/help.js
@@ -143,7 +143,7 @@ function getCommandOptionsEmbedFields(command, t) {
   else {
     fields.push({
       name: t('commands:help.arguments'),
-      value: getCommandOptionsDescription(command.data.options),
+      value: getCommandOptionsDescription(command.data.options, t),
     });
   }
   return fields;


### PR DESCRIPTION
Fix a bug with the command help