### PR TITLE
fix: german command descriptions & .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,14 +6,15 @@
 # Reference these in your code with process.env.<VARIABLE>
 
 # Bot's ID, used for command registering
-# # Production Bot
+# Production Bot
 BOT_ID="1234567890"
 # Develop Bot
 BETA_BOT_ID="1234567890"
 
 # Bot login token
-# Use the token from the Beta Bot in develop mode
 DISCORD_TOKEN="YourBotTokeAlphaNumericChain"
+# Token from the Beta Bot to use in develop mode
+BETA_DISCORD_TOKEN="YourBotTokeAlphaNumericChain"
 
 # Database URI
 DATABASE_URI="<protocole>://<user>:<password>@<host>:<port>/<database>?<options>"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
 	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
+
 		{
 			"type": "node",
 			"request": "launch",
@@ -30,6 +31,16 @@
 				"**/q.js"
 			],
 			"program": "${workspaceFolder}\\bot.js"
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Register Commands",
+			"skipFiles": [
+				"<node_internals>/**",
+				"**/q.js"
+			],
+			"program": "${workspaceFolder}\\register.js"
 		}
 	]
 }

--- a/src/locales/de/commands.yml
+++ b/src/locales/de/commands.yml
@@ -11,8 +11,8 @@ help:
   options:
     command:
       name: befehl
-      description: Weitere Informationen zu einem bestimmten Befehl anzeigen oder
-        „alle“ eingeben, um eine Liste aller Befehle anzuzeigen
+      description: Informationen zu einem Befehl anzeigen oder
+        „alle“ eingeben, um alle Befehle anzuzeigen
   deployedVersion: Bereitgestellte Version
   developer: Entwickler
   fullDescription: |-
@@ -42,8 +42,8 @@ roll:
   options:
     input:
       name: eingabe
-      description: Eine Zeichenfolge für die zu würfelnden Würfel im Format NdX!>XfX
-        (mehrere Würfe sind durch ein Leerzeichen zu trennen)
+      description: Die zu würfelnden Würfel im Format NdX!>XfX
+        (mehrere Würfe mit Leerzeichen trennen)
     abcd:
       name: abcd
       description: 'Folgende Angaben sind möglich: `12`, `10`, `8`, `6`, `a`, `b`,
@@ -165,7 +165,7 @@ conf:
     game:
       name: spiel
       description: Legt das Standardspiel für diesen Server fest (für Würfel-Skins
-        und Tabellen mit kritischen Verletzungen)
+        und kritische Verletzungen)
     locale:
       name: sprache
       description: Legt die Standardsprache für diesen Server fest (siehe Readme für


### PR DESCRIPTION
## Summary
I fixed some german command description translations that were too long.
Added an undocumented option to the .env.example file.
Added new launch option to register the slash commands, which makes it easier to debug.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->
### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes (wiki).