### PR TITLE
fix(Roll): 🐛 Correct bad regex execution for T2K/BR undefined inputs

### DIFF
--- a/src/commands/roll/roll.js
+++ b/src/commands/roll/roll.js
@@ -198,27 +198,29 @@ module.exports = class RollCommand extends SebediusCommand {
     // Parses roll string input (for Twilight 2000 & Blade Runner).
     if (game === YearZeroGames.TWILIGHT_2K || game === YearZeroGames.BLADE_RUNNER) {
       const input = interaction.options.getString('abcd')?.toLowerCase();
-      const Die = game === YearZeroGames.TWILIGHT_2K ? TwilightDie : BladeRunnerDie;
 
-      const inputRegex = /(?:(\d+)?d?(6|8|10|12))|([abcd])/g;
-      let result;
-      // https://stackoverflow.com/a/27753327
-      while ((result = inputRegex.exec(input)) !== null) {
-        // This is necessary to avoid infinite loops with zero-width matches
-        if (result.index === inputRegex.lastIndex) inputRegex.lastIndex++;
+      if (input) {
+        const Die = game === YearZeroGames.TWILIGHT_2K ? TwilightDie : BladeRunnerDie;
+        const inputRegex = /(?:(\d+)?d?(6|8|10|12))|([abcd])/g;
+        let result;
+        // https://stackoverflow.com/a/27753327
+        while ((result = inputRegex.exec(input)) !== null) {
+          // This is necessary to avoid infinite loops with zero-width matches
+          if (result.index === inputRegex.lastIndex) inputRegex.lastIndex++;
 
-        // $0 = whole match
-        // $1 = qty, digit before "d"
-        // $2 = faces, digit after "d"
-        // $3 = letter
-        const n = +result[1] || 1;
-        const d = result[2] || result[3];
-        switch (d) {
-          case '6': case 'd': roll.addDice(Die, n, { faces: 6 }); break;
-          case '8': case 'c': roll.addDice(Die, n, { faces: 8 }); break;
-          case '10': case 'b': roll.addDice(Die, n, { faces: 10 }); break;
-          case '12': case 'a': roll.addDice(Die, n, { faces: 12 }); break;
-          default: Logger.warn(`Roll Builder | Unknown roll string: "${d}"`);
+          // $0 = whole match
+          // $1 = qty, digit before "d"
+          // $2 = faces, digit after "d"
+          // $3 = letter
+          const n = +result[1] || 1;
+          const d = result[2] || result[3];
+          switch (d) {
+            case '6': case 'd': roll.addDice(Die, n, { faces: 6 }); break;
+            case '8': case 'c': roll.addDice(Die, n, { faces: 8 }); break;
+            case '10': case 'b': roll.addDice(Die, n, { faces: 10 }); break;
+            case '12': case 'a': roll.addDice(Die, n, { faces: 12 }); break;
+            default: Logger.warn(`Roll Builder | Unknown roll string: "${d}"`);
+          }
         }
       }
     }


### PR DESCRIPTION
There is a weird behavior when you execute a regex on an undefined variable, which for T2K and BR empty dice inputs resulted into two dice being rolled (instead of none).

This PR fixes this issue.